### PR TITLE
add ping source in connectivity test from vqfx1 to l-srv1/l-srv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ show route receive-protocol bgp 10.0.0.2
 
 ping 2.2.2.2
 ping 172.16.1.101 & 102
-ping 172.16.2.101 - 102
+ping 172.16.2.101 source 2.2.2.1
+ping 172.16.2.102 source 2.2.2.1
  ```
 
 Now after brining setup up and basic validation it's time to start installing Contrail CFM SW and basic use-cases testing. All validated use-cases are documented under folder "docs" and use following link for step to setp installations and validation.


### PR DESCRIPTION
ICMP ping from vQFX1 to l-srv1 and l-srv2 only succeeds when using lo0 as source, not xe-0/0/0. 

Alternatively, we could add the following Junos configuration to vqfx1 and vqfx2 to use the loopback IP as source for local sourced traffic:

```
set system default-address-selection
```

What would be the preferred method?
